### PR TITLE
Add a config option to adjust the wind's influence on particles

### DIFF
--- a/src/client/java/sh/talonfloof/enhancedweather/mixin/client/MixinParticle.java
+++ b/src/client/java/sh/talonfloof/enhancedweather/mixin/client/MixinParticle.java
@@ -36,11 +36,12 @@ public class MixinParticle {
     protected double velocityZ;
     @Inject(at = @At("TAIL"), method = "tick")
     private void applyWind(CallbackInfo ci) {
-        if(EnhancedWeather.CONFIG.Misc_DimensionWhitelist().contains(world.getDimensionKey().getValue().toString())) {
+        if(EnhancedWeather.CONFIG.Client_WindParticleInfluence() > 0F && EnhancedWeather.CONFIG.Misc_DimensionWhitelist().contains(world.getDimensionKey().getValue().toString())) {
             if (collidesWithWorld) {
                 if(world.getTopPosition(Heightmap.Type.MOTION_BLOCKING,new BlockPos((int)Math.floor(prevPosX),(int)Math.floor(prevPosY),(int)Math.floor(prevPosZ))).getY() <= prevPosY) {
-                    velocityX = EnhancedWeatherClient.windX/4F;
-                    velocityZ = EnhancedWeatherClient.windZ/4F;
+                    float f = EnhancedWeather.CONFIG.Client_WindParticleInfluence();
+                    velocityX = EnhancedWeatherClient.windX * f;
+                    velocityZ = EnhancedWeatherClient.windZ * f;
                 }
             }
         }

--- a/src/main/java/sh/talonfloof/enhancedweather/config/EnhancedWeatherConfigModel.java
+++ b/src/main/java/sh/talonfloof/enhancedweather/config/EnhancedWeatherConfigModel.java
@@ -17,6 +17,8 @@ public class EnhancedWeatherConfigModel {
     //@Comment("Changes the radius of clouds that are rendered\n(Default: 9)")
     @RangeConstraint(min=6,max=16)
     public int Client_CloudRadius = 9;
+    //@Comment("How much the wind will blow most particles (Except Cherry leaves, which always blow with the wind)\n(Default: 0.05)")
+    public float Client_WindParticleInfluence = 0.05F;
 
     @SectionHeader("weather")
     @Sync(value=Option.SyncMode.OVERRIDE_CLIENT)


### PR DESCRIPTION
I also lowered the effect to one fifth of what it originally was since I found the original speed to be pretty jarring and it can have lots of strange side effects with other mods.
I'd like to take a closer look at this at some point and see if I can maybe estimate a particles weight by how it's influenced by gravity but for now simply being able to turn the effect down or off is pretty handy. I left the Cherries alone because those particles are specifically designed to indicate wind and so they always look good.